### PR TITLE
fix(startup): ensure fullscreened main window is able to show after quick capture initialization on macOS Sequoia

### DIFF
--- a/electron/app/windows.ts
+++ b/electron/app/windows.ts
@@ -293,7 +293,13 @@ export const createSubWindows = (FRONTEND_PATH: string, ARGS: any) => {
 };
 
 const createQuickNoteWindow = (FRONTEND_PATH: string, ARGS: any) => {
+    const isFullScreen = appWindows.main?.isFullScreen();
     if (process.platform === 'darwin') {
+        if (isFullScreen) {
+            // Since macOS Sequoia, if you hide a fullscreen window, it will not show again
+            // This is a workaround to prevent that
+            appWindows.main.setFullScreen(false);
+        }
         app.dock.hide();
     }
 
@@ -345,6 +351,10 @@ const createQuickNoteWindow = (FRONTEND_PATH: string, ARGS: any) => {
     initializeSpellcheckDictionary(appWindows.quickNote);
     if (process.platform === 'darwin') {
         setTimeout(() => {
+            if (isFullScreen) {
+                // Restore the fullscreen state - macOS Sequoia workaround
+                appWindows.main.setFullScreen(true);
+            }
             app.dock.show();
         }, 500);
     }


### PR DESCRIPTION
<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Cal</h3></i></summary>

This PR introduces a workaround for macOS Sequoia to ensure that a fullscreened main window can be shown after quick capture initialization. It modifies the `createQuickNoteWindow` function to handle fullscreen state appropriately.

### Key Issues
None

<details>
<summary><h3>Files Changed</h3></summary>

<details open>
	<summary>File: <b>/electron/app/windows.ts</b></summary>
	Added logic to manage fullscreen state for the main window on macOS Sequoia during quick note window creation.
</details>


</details>

</details>
<!-- cal_description_end -->


