### PR TITLE
upgrade(uninstaller): remove files when uninstalling windows

### DIFF
--- a/electron/electron-builder.json
+++ b/electron/electron-builder.json
@@ -37,6 +37,9 @@
       }
     ]
   },
+  "nsis": {
+    "deleteAppDataOnUninstall": true
+  },
   "directories": {
     "output": "dist",
     "buildResources": "./build",


### PR DESCRIPTION
Fixes https://github.com/Acreom/app/issues/6

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adds a configuration to the NSIS settings to delete application data upon uninstallation on Windows.


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/Acreom/app/pull/8/files#diff-7e8fd64c911d29dc30ec78ac1fa81467058c50fa7bae791b03843131478362ec>electron/electron-builder.json</a></td><td>Added NSIS configuration to delete application data on uninstall.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.json`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->


