### PR TITLE
set loading to false

### DIFF
--- a/frontend/components/editor/extensions/image/ImageComponent.vue
+++ b/frontend/components/editor/extensions/image/ImageComponent.vue
@@ -181,6 +181,7 @@ export default class ImageComponent extends Vue {
 
     handleImageLoad(e: Event) {
         this.loaded = true;
+        this.updateAttributes({ loading: false });
     }
 
     handleOpenImage() {


### PR DESCRIPTION
I am not sure if this is the correct fix, but esentially the problem is, once I paste some image to the editor, it gets uploaded, but is stuck in loading forever. Only after switching pages, going to a random one and back to the one where image is pasted, the image shows normally.

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR sets the loading state to false after an image is loaded in the editor.


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/Acreom/app/pull/29/files#diff-4f177e1b5346716228a583378e20cf9bc6ae55f93ef1ce6ae7d42f125382b2bd>frontend/components/editor/extensions/image/ImageComponent.vue</a></td><td>Updated the image loading state to false upon successful image load.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->


